### PR TITLE
Remove duplicate token in c/ssac generator

### DIFF
--- a/java/src/libbun/encode/CGenerator.java
+++ b/java/src/libbun/encode/CGenerator.java
@@ -274,7 +274,6 @@ public class CGenerator extends ZSourceGenerator {
 		this.GenerateTypeName(Node.DeclType());
 		this.CurrentBuilder.Append(" ");
 		this.CurrentBuilder.Append(this.NameLocalVariable(Node.GetNameSpace(), Node.GetName()));
-		this.CurrentBuilder.AppendToken("=");
 		this.GenerateCode2(" = ", null, Node.InitValueNode(), this.SemiColon);
 		if(Node.HasNextVarNode()) {
 			this.VisitVarDeclNode(Node.NextVarNode());

--- a/java/src/libbun/encode/SSACGenerator.java
+++ b/java/src/libbun/encode/SSACGenerator.java
@@ -298,7 +298,6 @@ public class SSACGenerator extends ZSourceGenerator {
 		this.GenerateTypeName(Node.DeclType());
 		this.CurrentBuilder.Append(" ");
 		this.CurrentBuilder.Append(this.NameLocalVariable(Node.GetNameSpace(), Node.GetName()));
-		this.CurrentBuilder.AppendToken("=");
 		this.GenerateCode2(" = ", null, Node.InitValueNode(), this.SemiColon);
 		if(Node.HasNextVarNode()) {
 			this.VisitVarDeclNode(Node.NextVarNode());


### PR DESCRIPTION
This pull request fix CGenerator.VisitVarDeclNode().
