### PR TITLE
improve error report at float-number tokenizer

### DIFF
--- a/java/src/libbun/lang/bun/NumberLiteralTokenFunction.java
+++ b/java/src/libbun/lang/bun/NumberLiteralTokenFunction.java
@@ -33,6 +33,9 @@ public class NumberLiteralTokenFunction extends ZTokenFunction {
 						SourceContext.MoveNext();
 					}
 				}
+				if(SourceContext.HasChar() && !LibZen._IsDigit(SourceContext.GetCurrentChar())) {
+					SourceContext.LogWarning(StartIndex, "exponent has no digits");
+				}
 				NumberLiteralTokenFunction._ParseDigit(SourceContext);
 			}
 			SourceContext.Tokenize("$FloatLiteral$", StartIndex, SourceContext.GetPosition());


### PR DESCRIPTION
Acording to the issue that reported on https://github.com/konoha-project/libzen/issues/46 ,
When libbun's tokenizer parse invalid floating-number (e.g. `1.0e`), no error is reported.
This pull request improve error message for invalid floating-number format.
