### PR TITLE
support function call at CGenerator

### DIFF
--- a/java/src/libbun/encode/CGenerator.java
+++ b/java/src/libbun/encode/CGenerator.java
@@ -172,7 +172,13 @@ public class CGenerator extends ZSourceGenerator {
 	}
 
 	@Override public void VisitFuncCallNode(ZFuncCallNode Node) {
-		this.GenerateCode(null, Node.FunctorNode());
+		@Var ZFuncNameNode FuncNameNode = Node.FuncNameNode();
+		if(FuncNameNode != null) {
+			this.GenerateFuncName(FuncNameNode);
+		}
+		else {
+			this.GenerateCode(null, Node.FunctorNode());
+		}
 		this.VisitListNode("(", Node, ")");
 	}
 

--- a/java/src/libbun/encode/SSACGenerator.java
+++ b/java/src/libbun/encode/SSACGenerator.java
@@ -196,7 +196,13 @@ public class SSACGenerator extends ZSourceGenerator {
 	}
 
 	@Override public void VisitFuncCallNode(ZFuncCallNode Node) {
-		this.GenerateCode(null, Node.FunctorNode());
+		@Var ZFuncNameNode FuncNameNode = Node.FuncNameNode();
+		if(FuncNameNode != null) {
+			this.GenerateFuncName(FuncNameNode);
+		}
+		else {
+			this.GenerateCode(null, Node.FunctorNode());
+		}
 		this.VisitListNode("(", Node, ")");
 	}
 


### PR DESCRIPTION
Current version of libbun cannot generate function call correctly.
`$ cat call.bun
function g() {};
function f() { g(); }`

```
$ java -jar libbun-0.1.jar -t c call.bun
(call.bun:2) [error] undefined node:#ZFuncNameNode:?
        function f() { g(); }
                       ^

/* end of header */

static void g__0qqw();
static void f__0qqw();


static void g__0qqw() {
   return;
}
;

static void f__0qqw() {
   perror("(call.bun:2) [error] undefined node:#ZFuncNameNode:?\n\tfunction f() { g(); }\n\t               ^")();
   return;
}
```

This pull request supports function call.
