### PR TITLE
Improve common lisp

### DIFF
--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -362,8 +362,7 @@ public class CommonLispGenerator extends ZSourceGenerator {
 	}
 
 	@Override public void VisitLetNode(BLetVarNode Node) {
-		this.CurrentBuilder.AppendNewLine("(setf *", Node.GetUniqueName(this), "*");
-		this.GenerateTypeAnnotation(Node.DeclType());
+		this.CurrentBuilder.AppendNewLine("(setf ", Node.GetUniqueName(this), "");
 		this.CurrentBuilder.Append(" ");
 		this.GenerateCode(null, Node.InitValueNode());
 		this.CurrentBuilder.Append(")");

--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -167,7 +167,6 @@ public class CommonLispGenerator extends ZSourceGenerator {
 	protected void VisitVarDeclNode(BLetVarNode Node) {
 		this.CurrentBuilder.Append("(", this.NameLocalVariable(Node.GetNameSpace(), Node.GetGivenName()), " ");
 		this.GenerateCode(null, Node.InitValueNode());
-		this.GenerateCode(null, Node.InitValueNode());
 		this.CurrentBuilder.Append(")");
 		if(Node.HasNextVarNode()) {
 			this.VisitVarDeclNode(Node.NextVarNode());

--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -256,10 +256,24 @@ public class CommonLispGenerator extends ZSourceGenerator {
 		return null;
 	}
 
+	private String ClFunctionName(BFunctionNode FuncNode) {
+		String FuncName = FuncNode.FuncName();
+		if (FuncName != null) {
+			if (FuncName.equals("main")) {
+				return "main";
+			} else {
+				return FuncNode.GetSignature();
+			}
+		} else {
+			/// XXX
+			return "";
+		}
+	}
+
 	@Override public void VisitReturnNode(BReturnNode Node) {
 		@Var BFunctionNode FuncNode = this.LookupFunctionNode(Node);
 		if(FuncNode != null) {
-			this.CurrentBuilder.Append("(return-from ", FuncNode.GetSignature(), " ");
+			this.CurrentBuilder.Append("(return-from ", ClFunctionName(FuncNode), " ");
 		}
 		else {
 			this.CurrentBuilder.Append("(return ");
@@ -287,7 +301,7 @@ public class CommonLispGenerator extends ZSourceGenerator {
 		else {
 			@Var BFuncType FuncType = Node.GetFuncType();
 			this.CurrentBuilder.Append("(defun ");
-			this.CurrentBuilder.Append(Node.GetSignature());
+			this.CurrentBuilder.Append(ClFunctionName(Node));
 			this.VisitFuncParamNode(" (", Node, ")");
 			this.GenerateCode(null, Node.BlockNode());
 			this.CurrentBuilder.Append(")");

--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -379,22 +379,32 @@ public class CommonLispGenerator extends ZSourceGenerator {
 	}
 
 	@Override public void VisitArrayLiteralNode(BArrayLiteralNode Node) {
-		this.VisitListNode("#(", Node, ")");
+		this.VisitListNode("'(", Node, ")");
 	}
 
 	@Override public void VisitGetIndexNode(BGetIndexNode Node) {
-		this.CurrentBuilder.Append("(aref ");
-		this.GenerateCode(null, Node.RecvNode());
-		this.CurrentBuilder.Append(" ");
-		this.GenerateCode(null, Node.IndexNode());
+		this.CurrentBuilder.Append("(");
+		if (Node.RecvNode().Type == BType.StringType) {
+			this.CurrentBuilder.Append("string (");
+			this.CurrentBuilder.Append("aref ");
+			this.GenerateCode(null, Node.RecvNode());
+			this.CurrentBuilder.Append(" ");
+			this.GenerateCode(null, Node.IndexNode());
+			this.CurrentBuilder.Append(") ");
+		} else {
+			this.CurrentBuilder.Append("nth ");
+			this.GenerateCode(null, Node.IndexNode());
+			this.CurrentBuilder.Append(" ");
+			this.GenerateCode(null, Node.RecvNode());
+		}
 		this.CurrentBuilder.Append(")");
 	}
 
 	@Override public void VisitSetIndexNode(BSetIndexNode Node) {
-		this.CurrentBuilder.Append("(setf (aref ");
-		this.GenerateCode(null, Node.RecvNode());
-		this.CurrentBuilder.Append(" ");
+		this.CurrentBuilder.Append("(setf (nth ");
 		this.GenerateCode(null, Node.IndexNode());
+		this.CurrentBuilder.Append(" ");
+		this.GenerateCode(null, Node.RecvNode());
 		this.CurrentBuilder.Append(") ");
 		this.GenerateCode(null, Node.ExprNode());
 		this.CurrentBuilder.Append(")");

--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -102,9 +102,7 @@ public class CommonLispGenerator extends ZSourceGenerator {
 	}
 
 	private String GetBinaryOperator(BToken Token) {
-		if(Token.EqualsText("!=")) {
-			return "!=";
-		} else if(Token.EqualsText("==")) {
+		if(Token.EqualsText("==")) {
 			return "equal";
 		} else if(Token.EqualsText("%")) {
 			return "mod";
@@ -116,21 +114,38 @@ public class CommonLispGenerator extends ZSourceGenerator {
 
 	@Override public void VisitBinaryNode(BBinaryNode Node) {
 		this.CurrentBuilder.Append("(");
-		this.CurrentBuilder.Append(Node.SourceToken.GetText());
+		String operator = GetBinaryOperator(Node.SourceToken);
+		if (operator.equals("/")) {
+			this.CurrentBuilder.Append("floor" + " ");
+			this.CurrentBuilder.Append("(");
+		}
+		this.CurrentBuilder.Append(operator);
 		this.CurrentBuilder.Append(" ");
 		this.GenerateCode(null, Node.LeftNode());
 		this.CurrentBuilder.Append(" ");
 		this.GenerateCode(null, Node.RightNode());
+		if (operator.equals("/")) {
+			this.CurrentBuilder.Append(")");
+		}
 		this.CurrentBuilder.Append(")");
 	}
 
 	@Override public void VisitComparatorNode(BComparatorNode Node) {
 		this.CurrentBuilder.Append("(");
-		this.CurrentBuilder.Append(this.GetBinaryOperator(Node.SourceToken));
+		String operator = this.GetBinaryOperator(Node.SourceToken);
+		if (operator.equals("!=")) {
+			this.CurrentBuilder.Append("not" + " ");
+			this.CurrentBuilder.Append("(equal");
+		} else {
+			this.CurrentBuilder.Append(operator);
+		}
 		this.CurrentBuilder.Append(" ");
 		this.GenerateCode(null, Node.LeftNode());
 		this.CurrentBuilder.Append(" ");
 		this.GenerateCode(null, Node.RightNode());
+		if (operator.equals("!=")) {
+			this.CurrentBuilder.Append(")");
+		}
 		this.CurrentBuilder.Append(")");
 	}
 

--- a/test/bin/test_common_lisp
+++ b/test/bin/test_common_lisp
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+OUTDIR=test/w TARGET=cl CHECK=clisp test/bin/buntest test/bun/*.bun


### PR DESCRIPTION
Current test status is as below.

```
% sh ./test/bin/test_common_lisp
[OK] G1_HelloWorld (clisp test/w/G1_HelloWorld.cl)
[OK] G2_BinaryOperator (clisp test/w/G2_BinaryOperator.cl)
[OK] G2_Function (clisp test/w/G2_Function.cl)
[OK] G2_Grouping (clisp test/w/G2_Grouping.cl)
[OK] G3_FunctionNoReturn (clisp test/w/G3_FunctionNoReturn.cl)
[OK] G3_FunctionParameter (clisp test/w/G3_FunctionParameter.cl)
[OK] G3_If (clisp test/w/G3_If.cl)
[OK] G3_Let (clisp test/w/G3_Let.cl)
[OK] G3_Prototype (clisp test/w/G3_Prototype.cl)
[OK] G3_Throw (clisp test/w/G3_Throw.cl)
[OK] G3_Try (clisp test/w/G3_Try.cl)
[OK] G3_Var (clisp test/w/G3_Var.cl)
[OK] G3_While (clisp test/w/G3_While.cl)
[OK] G3_WhileBreak (clisp test/w/G3_WhileBreak.cl)
[OK] G4_Boolean (clisp test/w/G4_Boolean.cl)
[OK] G4_Float (clisp test/w/G4_Float.cl)
[OK] G4_Int (clisp test/w/G4_Int.cl)
[OK] G4_IntArray (clisp test/w/G4_IntArray.cl)
[FAILED] G4_IntMap (clisp test/w/G4_IntMap.cl)
*** - READ: comma is illegal outside of backquote
[OK] G4_Null (clisp test/w/G4_Null.cl)
[OK] G4_String (clisp test/w/G4_String.cl)
[FAILED] G4_ZeroDivided (clisp test/w/G4_ZeroDivided.cl)
*** - PROGN: variable E has no value

[FAILED] G5_ApplyFunction (clisp test/w/G5_ApplyFunction.cl)
*** - EVAL: undefined function FUNCCALL

[FAILED] G5_LetFunction (clisp test/w/G5_LetFunction.cl)
*** - EVAL: undefined function FUNCCALL

[FAILED] G5_VarFunction (clisp test/w/G5_VarFunction.cl)
*** - EVAL: undefined function FUNCCALL

[FAILED] G6_Class (clisp test/w/G6_Class.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_Constructor (clisp test/w/G6_Constructor.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_DynamicBinding (clisp test/w/G6_DynamicBinding.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_InstanceOf (clisp test/w/G6_InstanceOf.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_SubClass (clisp test/w/G6_SubClass.cl)
*** - EVAL: variable CLASS has no value

[OK] G7_InferFunction (clisp test/w/G7_InferFunction.cl)
[OK] G8_Continue (clisp test/w/G8_Continue.cl)
[FAILED] G8_Math (clisp test/w/G8_Math.cl)
*** - READ from
      #<INPUT BUFFERED FILE-STREAM CHARACTER #P"test/w/G8_Math.cl" @5>: there
            is no package with name "ERROR"

[FAILED] G9_BinaryTrees (clisp test/w/G9_BinaryTrees.cl)
*** - EVAL: variable CLASS has no value

[OK] G9_BubbleSort (clisp test/w/G9_BubbleSort.cl)
[OK] G9_Fibonacci (clisp test/w/G9_Fibonacci.cl)
[FAILED] G9_MathSqrt (clisp test/w/G9_MathSqrt.cl)
*** - (<= (- 1.4142135 (SQRT__1QQT 2.0)) 1.0E-4) must evaluate to a non-NIL
      value.
      [FAILED] Gx_Closure (clisp test/w/Gx_Closure.cl)
      *** - EVAL: undefined function FUNCCALL

[OK] Gx_EvenOdd (clisp test/w/Gx_EvenOdd.cl)
[OK] Gx_Utf8String (clisp test/w/Gx_Utf8String.cl)
# of OK: 26, # of FAILED: 14
```
