### PR TITLE
Improve commonlisp for lamba

### DIFF
--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -280,8 +280,8 @@ public class CommonLispGenerator extends ZSourceGenerator {
 				return FuncNode.GetSignature();
 			}
 		} else {
-			/// XXX
-			return "";
+			// wrapped nil block
+			return "nil";
 		}
 	}
 
@@ -310,8 +310,9 @@ public class CommonLispGenerator extends ZSourceGenerator {
 		if(!Node.IsTopLevelDefineFunction()) {
 			this.CurrentBuilder.Append("#'(lambda ");
 			this.VisitFuncParamNode("(", Node, ")");
+			this.CurrentBuilder.Append("(block nil ");
 			this.GenerateCode(null, Node.BlockNode());
-			this.CurrentBuilder.Append(")");
+			this.CurrentBuilder.Append("))");
 		}
 		else {
 			@Var BFuncType FuncType = Node.GetFuncType();

--- a/java/src/libbun/encode/CommonLispGenerator.java
+++ b/java/src/libbun/encode/CommonLispGenerator.java
@@ -254,7 +254,7 @@ public class CommonLispGenerator extends ZSourceGenerator {
 			this.GenerateFuncName(FuncNameNode);
 		}
 		else {
-			this.CurrentBuilder.Append("funccall ");
+			this.CurrentBuilder.Append("funcall ");
 			this.GenerateCode(null, Node.FunctorNode());
 		}
 		this.VisitListNode(" ", Node, " ");


### PR DESCRIPTION
3 tests are passed by this fix.

```
% sh ./test/bin/test_common_lisp
[OK] G1_HelloWorld (clisp test/w/G1_HelloWorld.cl)
[OK] G2_BinaryOperator (clisp test/w/G2_BinaryOperator.cl)
[OK] G2_Function (clisp test/w/G2_Function.cl)
[OK] G2_Grouping (clisp test/w/G2_Grouping.cl)
[OK] G3_FunctionNoReturn (clisp test/w/G3_FunctionNoReturn.cl)
[OK] G3_FunctionParameter (clisp test/w/G3_FunctionParameter.cl)
[OK] G3_If (clisp test/w/G3_If.cl)
[OK] G3_Let (clisp test/w/G3_Let.cl)
[OK] G3_Prototype (clisp test/w/G3_Prototype.cl)
[OK] G3_Throw (clisp test/w/G3_Throw.cl)
[OK] G3_Try (clisp test/w/G3_Try.cl)
[OK] G3_Var (clisp test/w/G3_Var.cl)
[OK] G3_While (clisp test/w/G3_While.cl)
[OK] G3_WhileBreak (clisp test/w/G3_WhileBreak.cl)
[OK] G4_Boolean (clisp test/w/G4_Boolean.cl)
[OK] G4_Float (clisp test/w/G4_Float.cl)
[OK] G4_Int (clisp test/w/G4_Int.cl)
[OK] G4_IntArray (clisp test/w/G4_IntArray.cl)
[FAILED] G4_IntMap (clisp test/w/G4_IntMap.cl)
*** - READ: comma is illegal outside of backquote
[OK] G4_Null (clisp test/w/G4_Null.cl)
[OK] G4_String (clisp test/w/G4_String.cl)
[FAILED] G4_ZeroDivided (clisp test/w/G4_ZeroDivided.cl)
*** - PROGN: variable E has no value

[OK] G5_ApplyFunction (clisp test/w/G5_ApplyFunction.cl)
[OK] G5_LetFunction (clisp test/w/G5_LetFunction.cl)
[OK] G5_VarFunction (clisp test/w/G5_VarFunction.cl)
[FAILED] G6_Class (clisp test/w/G6_Class.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_Constructor (clisp test/w/G6_Constructor.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_DynamicBinding (clisp test/w/G6_DynamicBinding.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_InstanceOf (clisp test/w/G6_InstanceOf.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_SubClass (clisp test/w/G6_SubClass.cl)
*** - EVAL: variable CLASS has no value

[OK] G7_InferFunction (clisp test/w/G7_InferFunction.cl)
[OK] G8_Continue (clisp test/w/G8_Continue.cl)
[FAILED] G8_Math (clisp test/w/G8_Math.cl)
*** - READ from
      #<INPUT BUFFERED FILE-STREAM CHARACTER #P"test/w/G8_Math.cl" @5>: there
      is no package with name "ERROR"

[FAILED] G9_BinaryTrees (clisp test/w/G9_BinaryTrees.cl)
*** - EVAL: variable CLASS has no value

[OK] G9_BubbleSort (clisp test/w/G9_BubbleSort.cl)
[OK] G9_Fibonacci (clisp test/w/G9_Fibonacci.cl)
[FAILED] G9_MathSqrt (clisp test/w/G9_MathSqrt.cl)
*** - (<= (- 1.4142135 (SQRT__1QQT 2.0)) 1.0E-4) must evaluate to a non-NIL
      value.
[FAILED] Gx_Closure (clisp test/w/Gx_Closure.cl)
*** - (EQUAL (FUNCALL SUCC 1) 0) must evaluate to a non-NIL value.
[OK] Gx_EvenOdd (clisp test/w/Gx_EvenOdd.cl)
[OK] Gx_Utf8String (clisp test/w/Gx_Utf8String.cl)
# of OK: 29, # of FAILED: 11
```
