### PR TITLE
Fix JS Generator

### DIFF
--- a/java/src/libbun/encode/JavaScriptGenerator.java
+++ b/java/src/libbun/encode/JavaScriptGenerator.java
@@ -93,9 +93,7 @@ public class JavaScriptGenerator extends OldSourceGenerator {
 	@Override public void VisitInstanceOfNode(BInstanceOfNode Node) {
 		this.Source.Append("(");
 		this.GenerateCode(null, Node.LeftNode());
-		this.Source.Append(").constructor.name === ");
-		this.GenerateTypeName(Node.TargetType());
-		this.Source.Append(".name");
+		this.Source.Append(").constructor.name === ", this.NameClass(Node.TargetType()), ".name");
 	}
 
 	@Override public void VisitThrowNode(BunThrowNode Node) {

--- a/java/src/libbun/encode/JavaScriptGenerator.java
+++ b/java/src/libbun/encode/JavaScriptGenerator.java
@@ -82,7 +82,7 @@ public class JavaScriptGenerator extends OldSourceGenerator {
 	}
 
 	@Override public void VisitNewObjectNode(NewObjectNode Node) {
-		this.Source.Append(this.NameClass(Node.Type));
+		this.Source.Append("new ", this.NameClass(Node.Type));
 		this.VisitListNode("(", Node, ")");
 	}
 

--- a/java/src/libbun/encode/OldSourceGenerator.java
+++ b/java/src/libbun/encode/OldSourceGenerator.java
@@ -294,7 +294,7 @@ public class OldSourceGenerator extends SourceGenerator {
 		if(ResolvedNode == null && !this.LangInfo.AllowUndefinedSymbol) {
 			BLogger._LogError(Node.SourceToken, "undefined symbol: " + Node.GivenName);
 		}
-		this.Source.Append(Node.GetUniqueName(this));
+		this.Source.Append(this.NameLocalVariable(Node.GetNameSpace(), Node.GetUniqueName(this)));
 	}
 
 	@Override public void VisitSetNameNode(SetNameNode Node) {

--- a/test/bun/Gx_Closure.bun
+++ b/test/bun/Gx_Closure.bun
@@ -18,7 +18,7 @@ export function main() {
 	assert(succ(1) == 2);
 	assert(apply(succ,1) == 2);
 	inc = 0;
-	assert(succ(1) == 0);
-	assert(apply(succ,1) == 0);
+	assert(succ(1) == 1);
+	assert(apply(succ,1) == 1);
 }
 


### PR DESCRIPTION
Fixed JavaScriptGenerator, OldSourceGenerator and wrong tests in Gx_Closure.bun.

```
[OK] G1_HelloWorld (node test/w/G1_HelloWorld.js)
[OK] G2_BinaryOperator (node test/w/G2_BinaryOperator.js)
[OK] G2_Function (node test/w/G2_Function.js)
[OK] G2_Grouping (node test/w/G2_Grouping.js)
[OK] G3_FunctionNoReturn (node test/w/G3_FunctionNoReturn.js)
[OK] G3_FunctionParameter (node test/w/G3_FunctionParameter.js)
[OK] G3_If (node test/w/G3_If.js)
[OK] G3_Let (node test/w/G3_Let.js)
[OK] G3_Prototype (node test/w/G3_Prototype.js)
[OK] G3_Throw (node test/w/G3_Throw.js)
[OK] G3_Try (node test/w/G3_Try.js)
[OK] G3_Var (node test/w/G3_Var.js)
[OK] G3_While (node test/w/G3_While.js)
[OK] G3_WhileBreak (node test/w/G3_WhileBreak.js)
[OK] G4_Boolean (node test/w/G4_Boolean.js)
[OK] G4_Float (node test/w/G4_Float.js)
[OK] G4_Int (node test/w/G4_Int.js)
[OK] G4_IntArray (node test/w/G4_IntArray.js)
[FAILED] G4_IntMap (node test/w/G4_IntMap.js)
[OK] G4_Null (node test/w/G4_Null.js)
[OK] G4_String (node test/w/G4_String.js)
[FAILED] G4_ZeroDivided (node test/w/G4_ZeroDivided.js)
[OK] G5_ApplyFunction (node test/w/G5_ApplyFunction.js)
[OK] G5_LetFunction (node test/w/G5_LetFunction.js)
[OK] G5_VarFunction (node test/w/G5_VarFunction.js)
[OK] G6_Class (node test/w/G6_Class.js)
[OK] G6_Constructor (node test/w/G6_Constructor.js)
[OK] G6_DynamicBinding (node test/w/G6_DynamicBinding.js)
[OK] G6_InstanceOf (node test/w/G6_InstanceOf.js)
[OK] G6_SubClass (node test/w/G6_SubClass.js)
[OK] G7_InferFunction (node test/w/G7_InferFunction.js)
[OK] G8_Continue (node test/w/G8_Continue.js)
[OK] G8_Math (node test/w/G8_Math.js)
[OK] G9_BinaryTrees (node test/w/G9_BinaryTrees.js)
[OK] G9_BubbleSort (node test/w/G9_BubbleSort.js)
[OK] G9_Fibonacci (node test/w/G9_Fibonacci.js)
[OK] G9_MathSqrt (node test/w/G9_MathSqrt.js)
[OK] Gx_Closure (node test/w/Gx_Closure.js)
[OK] Gx_EvenOdd (node test/w/Gx_EvenOdd.js)
[OK] Gx_Utf8String (node test/w/Gx_Utf8String.js)
# of OK: 38, # of FAILED: 2
```
