### PR TITLE
Fix JavaScriptGenerator.VisitErrorNode to use SoftwareFault.

### DIFF
--- a/java/src/libbun/encode/JavaScriptGenerator.java
+++ b/java/src/libbun/encode/JavaScriptGenerator.java
@@ -28,7 +28,6 @@ package libbun.encode;
 import libbun.ast.BNode;
 import libbun.ast.BunBlockNode;
 import libbun.ast.GroupNode;
-import libbun.ast.binary.BunInstanceOfNode;
 import libbun.ast.binary.BinaryOperatorNode;
 import libbun.ast.binary.BunAddNode;
 import libbun.ast.binary.BunAndNode;
@@ -39,6 +38,7 @@ import libbun.ast.binary.BunDivNode;
 import libbun.ast.binary.BunEqualsNode;
 import libbun.ast.binary.BunGreaterThanEqualsNode;
 import libbun.ast.binary.BunGreaterThanNode;
+import libbun.ast.binary.BunInstanceOfNode;
 import libbun.ast.binary.BunLeftShiftNode;
 import libbun.ast.binary.BunLessThanEqualsNode;
 import libbun.ast.binary.BunLessThanNode;
@@ -137,10 +137,10 @@ public class JavaScriptGenerator extends LibBunSourceGenerator {
 		this.Source.Append("try");
 		this.GenerateExpression(Node.TryBlockNode());
 		if(Node.HasCatchBlockNode()){
-			@Var String VarName = this.NameUniqueSymbol("e");
+			@Var String VarName = Node.ExceptionName();
 			this.ImportLibrary("@catch");
 			this.Source.Append("catch(", VarName, "){ ");
-			this.Source.Append(Node.ExceptionName(), " = libbun_catch(", VarName);
+			this.Source.Append(VarName, " = libbun_catch(", VarName);
 			this.Source.Append("); ");
 			this.GenerateExpression(Node.CatchBlockNode());
 			this.Source.Append("}");
@@ -261,9 +261,10 @@ public class JavaScriptGenerator extends LibBunSourceGenerator {
 			this.GenerateExpression(ErrorNode.ErrorNode);
 		}
 		else {
+			this.ImportLibrary("@SoftwareFault");
 			@Var String Message = LibBunLogger._LogError(Node.SourceToken, Node.ErrorMessage);
 			this.Source.AppendWhiteSpace();
-			this.Source.Append("(function(){ throw new Error(");
+			this.Source.Append("(function(){ throw new SoftwareFault(");
 			this.Source.Append(BLib._QuoteString(Message));
 			this.Source.Append("); })()");
 		}


### PR DESCRIPTION
This fix is necessary to path G4_SyntaxError.

```
[OK] G0_HelloWorld (node test/w/G0_HelloWorld.js)
[OK] G1_Function (node test/w/G1_Function.js)
[OK] G1_Grouping (node test/w/G1_Grouping.js)
[OK] G1_If (node test/w/G1_If.js)
[OK] G1_Let (node test/w/G1_Let.js)
[OK] G1_Operator (node test/w/G1_Operator.js)
[OK] G1_Var (node test/w/G1_Var.js)
[OK] G1_While (node test/w/G1_While.js)
[OK] G1_WhileBreak (node test/w/G1_WhileBreak.js)
[OK] G2_CrossReferenceFunction (node test/w/G2_CrossReferenceFunction.js)
[OK] G2_FunctionNoReturn (node test/w/G2_FunctionNoReturn.js)
[OK] G2_FunctionParameter (node test/w/G2_FunctionParameter.js)
[OK] G2_LetInFunction (node test/w/G2_LetInFunction.js)
[OK] G2_Precedence (node test/w/G2_Precedence.js)
[OK] G3_Boolean (node test/w/G3_Boolean.js)
[OK] G3_Float (node test/w/G3_Float.js)
[OK] G3_Int (node test/w/G3_Int.js)
[OK] G3_IntArray (node test/w/G3_IntArray.js)
[OK] G3_IntMap (node test/w/G3_IntMap.js)
[OK] G3_Null (node test/w/G3_Null.js)
[OK] G3_String (node test/w/G3_String.js)
[OK] G4_KeyNotFound (node test/w/G4_KeyNotFound.js)
[OK] G4_OutOfIndex (node test/w/G4_OutOfIndex.js)
[OK] G4_SyntaxError (node test/w/G4_SyntaxError.js)
[OK] G4_Throw (node test/w/G4_Throw.js)
[OK] G4_Try (node test/w/G4_Try.js)
[OK] G4_ZeroDivision (node test/w/G4_ZeroDivision.js)
[OK] G5_ApplyFunction (node test/w/G5_ApplyFunction.js)
[OK] G5_LetFunction (node test/w/G5_LetFunction.js)
[OK] G5_VarFunction (node test/w/G5_VarFunction.js)
[OK] G6_Class (node test/w/G6_Class.js)
[OK] G6_Constructor (node test/w/G6_Constructor.js)
[OK] G6_DynamicBinding (node test/w/G6_DynamicBinding.js)
[OK] G6_InstanceOf (node test/w/G6_InstanceOf.js)
[OK] G6_SubClass (node test/w/G6_SubClass.js)
[OK] G7_InferFunction (node test/w/G7_InferFunction.js)
[OK] G8_Continue (node test/w/G8_Continue.js)
[OK] G8_Math (node test/w/G8_Math.js)
[OK] G9_BinaryTrees (node test/w/G9_BinaryTrees.js)
[OK] G9_BubbleSort (node test/w/G9_BubbleSort.js)
[OK] G9_Fibonacci (node test/w/G9_Fibonacci.js)
[OK] G9_MathSqrt (node test/w/G9_MathSqrt.js)
[OK] Gx_Utf8String (node test/w/Gx_Utf8String.js)
# of OK: 43, # of FAILED: 0
```
