### PR TITLE
Improve common lisp

### DIFF
--- a/java/src/libbun/encode/playground/CommonLispGenerator.java
+++ b/java/src/libbun/encode/playground/CommonLispGenerator.java
@@ -673,7 +673,7 @@ public class CommonLispGenerator extends LibBunSourceGenerator {
 			}
 			i = i + 1;
 		}
-		this.Source.Append("(format nil \"" + Format + "\"");
+		this.Source.Append("(format nil \"" + Format.replaceAll("\"", "\\\\\"") + "\"");
 		if(Node.size() > 1) {
 			this.Source.Append(" ");
 			i = 1;

--- a/java/src/libbun/encode/playground/CommonLispGenerator.java
+++ b/java/src/libbun/encode/playground/CommonLispGenerator.java
@@ -129,17 +129,7 @@ public class CommonLispGenerator extends LibBunSourceGenerator {
 	}
 
 	@Override public void VisitArrayLiteralNode(BunArrayNode Node) {
-		//		this.Source.Append("(let ((a (make-array 8 :adjustable T :fill-pointer 0 :initial-element 'e)))");
-		this.Source.Append("(let ((a (make-array ");
-		this.Source.AppendInt(Node.size());
-		this.Source.Append(" :initial-element ", this.InitArrayValue(Node));
-		this.Source.Append(" :adjustable T :fill-pointer 0)))");
-		@Var int i = 0;
-		while(i < Node.size()) {
-			this.GenerateExpression(" (vector-push ", Node.get(i), " a)");
-			i = i + 1;
-		}
-		this.Source.Append(" a)");
+		this.GenerateListNode("(list ", Node, 0, " ", ")");
 	}
 
 	private String InitArrayValue(BunArrayNode Node) {

--- a/java/src/libbun/encode/playground/CommonLispGenerator.java
+++ b/java/src/libbun/encode/playground/CommonLispGenerator.java
@@ -338,7 +338,7 @@ public class CommonLispGenerator extends LibBunSourceGenerator {
 			this.Source.Append("))");
 		}
 		else {
-			this.Source.Append("(/");
+			this.Source.Append("(/ ");
 			this.GenerateExpression(Node.LeftNode());
 			this.Source.Append(" ");
 			this.GenerateExpression(Node.RightNode());

--- a/java/src/libbun/encode/playground/CommonLispGenerator.java
+++ b/java/src/libbun/encode/playground/CommonLispGenerator.java
@@ -306,7 +306,20 @@ public class CommonLispGenerator extends LibBunSourceGenerator {
 	}
 
 	@Override public void VisitDivNode(BunDivNode Node) {
-		this.GenerateBinaryNode(Node.GetOperator(), Node, null);
+		if(Node.Type.IsIntType()) {
+			this.Source.Append("(floor (/ ");
+			this.GenerateExpression(Node.LeftNode());
+			this.Source.Append(" ");
+			this.GenerateExpression(Node.RightNode());
+			this.Source.Append("))");
+		}
+		else {
+			this.Source.Append("(/");
+			this.GenerateExpression(Node.LeftNode());
+			this.Source.Append(" ");
+			this.GenerateExpression(Node.RightNode());
+			this.Source.Append(")");
+		}
 	}
 
 	@Override public void VisitModNode(BunModNode Node) {

--- a/lib/cl/common.bun
+++ b/lib/cl/common.bun
@@ -23,8 +23,9 @@ define trim "(string-trim '(#\\Space) $[0])": Func<String,String>
 define _ "~(format nil \"~a\" $[0])": Func<α[],String>
 define size "(length $[0])": Func<α[],int>
 define size "(FIXME)": Func<α[],int,void>
-define add "(vector-push $[1])": Func<α[],α,void>
-define pop "(vector-pop $[0])": Func<α[],α>
+define add "(setf $[0] (append $[0] (list $[1])))": Func<α[],α,void>
+define insert "(push $[2] (cdr (nthcdr (1- $[1]) $[0])))": Func<α[],int,α,void>
+define pop "(let* ((_r (reverse $[0]))(_a (car _r)))(prog1 _a (setf $[0] (reverse (cdr _r)))))": Func<α[],α>
 define hasKey "(gethash $[1] $[0])": Func<Map<α>,String,boolean>
 define get "(gethash $[1] $[0])": Func<Map<α>,String,α>
 define _ "~(format nil \"~a\" $[0])": Func<Object,String>

--- a/lib/cl/inline.cl
+++ b/lib/cl/inline.cl
@@ -1,0 +1,42 @@
+;; @main
+(main)
+
+;; @extend
+(defclass Object () (()))
+
+;; @Fault
+(define-condition Fault (error)
+  ((msg :initarg :msg :reader msg)))
+
+;; @SoftwareFault;@Fault
+(define-condition SoftwareFault (Fault)
+  ())
+
+;; @catch;@SoftwareFault
+(defun libbun-catch (e)
+  (cond ((eq (type-of e) 'Fault) e)
+        ((or (eq (type-of e) 'division-by-zero) ; sbcl
+             (eq (type-of e) 'system::simple-division-by-zero)) ; clisp
+         (let ((e1 (make-instance 'SoftwareFault)))
+           (setf (slot-value e1 'msg) "division-by-zero")
+           e1))
+        (t e)))
+
+;; @mapget;@SoftwareFault
+(defun libbun-mapget (m k &optional v)
+  (multiple-value-bind (value found) (gethash k m)
+    (if (not found)
+        (or v (error 'SoftwareFault))
+      value)))
+
+;; @arrayget;@SoftwareFault
+(defun libbun-arrayget (a i)
+  (if (and (>= i 0) (< i (length a)))
+      (nth i a)
+    (error 'SoftwareFault)))
+
+;; @arrayset;@SoftwareFault
+(defun libbun-arrayset (a i v)
+  (if (and (>= i 0) (< i (length a)))
+      (setf (nth i a) v)
+    (error 'SoftwareFault)))


### PR DESCRIPTION
#### before

```
% OUTDIR=test/w TARGET=cl CHECK=clisp test/bin/buntest test/bun/G*.bun
[OK] G0_HelloWorld (clisp test/w/G0_HelloWorld.cl)
[OK] G1_Function (clisp test/w/G1_Function.cl)
[OK] G1_Grouping (clisp test/w/G1_Grouping.cl)
[OK] G1_If (clisp test/w/G1_If.cl)
[OK] G1_Let (clisp test/w/G1_Let.cl)
[FAILED] G1_Operator (clisp test/w/G1_Operator.cl)
*** - (EQUAL (/ X Y) 1) must evaluate to a non-NIL value.
[OK] G1_StringInterpolation (clisp test/w/G1_StringInterpolation.cl)
[OK] G1_Var (clisp test/w/G1_Var.cl)
[OK] G1_While (clisp test/w/G1_While.cl)
[OK] G1_WhileBreak (clisp test/w/G1_WhileBreak.cl)
[OK] G2_Asm (clisp test/w/G2_Asm.cl)
[OK] G2_CrossReferenceFunction (clisp test/w/G2_CrossReferenceFunction.cl)
[OK] G2_FunctionNoReturn (clisp test/w/G2_FunctionNoReturn.cl)
[OK] G2_FunctionParameter (clisp test/w/G2_FunctionParameter.cl)
[OK] G2_LetInFunction (clisp test/w/G2_LetInFunction.cl)
[OK] G2_Precedence (clisp test/w/G2_Precedence.cl)
[OK] G3_Boolean (clisp test/w/G3_Boolean.cl)
[OK] G3_Float (clisp test/w/G3_Float.cl)
[OK] G3_Int (clisp test/w/G3_Int.cl)
[FAILED] G3_IntArray (clisp test/w/G3_IntArray.cl)
*** - READ: comma is illegal outside of backquote
[OK] G3_IntMap (clisp test/w/G3_IntMap.cl)
[OK] G3_Null (clisp test/w/G3_Null.cl)
[FAILED] G3_String (clisp test/w/G3_String.cl)
*** - PROGN: variable BC has no value

[OK] G3_StringConcat (clisp test/w/G3_StringConcat.cl)
[OK] G3_StringInterpolation (clisp test/w/G3_StringInterpolation.cl)
[FAILED] G4_KeyNotFound (clisp test/w/G4_KeyNotFound.cl)
*** - ENDP: A proper list must not end with INSTANCEOF

[FAILED] G4_OutOfIndex (clisp test/w/G4_OutOfIndex.cl)
*** - ENDP: A proper list must not end with INSTANCEOF

[FAILED] G4_SyntaxError (clisp test/w/G4_SyntaxError.cl)
*** - READ from
      #<INPUT BUFFERED FILE-STREAM CHARACTER #P"test/w/G4_SyntaxError.cl" @5>:
      there is no package with name "TEST/BUN/G4_SYNTAXERROR.BUN"

[OK] G4_Throw (clisp test/w/G4_Throw.cl)
[OK] G4_Try (clisp test/w/G4_Try.cl)
[FAILED] G4_ZeroDivision (clisp test/w/G4_ZeroDivision.cl)
*** - ENDP: A proper list must not end with INSTANCEOF

[OK] G5_ApplyFunction (clisp test/w/G5_ApplyFunction.cl)
[OK] G5_LetFunction (clisp test/w/G5_LetFunction.cl)
[OK] G5_VarFunction (clisp test/w/G5_VarFunction.cl)
[FAILED] G6_Class (clisp test/w/G6_Class.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_Constructor (clisp test/w/G6_Constructor.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_DynamicBinding (clisp test/w/G6_DynamicBinding.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_InstanceOf (clisp test/w/G6_InstanceOf.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G6_SubClass (clisp test/w/G6_SubClass.cl)
*** - EVAL: variable CLASS has no value

[OK] G7_InferFunction (clisp test/w/G7_InferFunction.cl)
[OK] G8_Continue (clisp test/w/G8_Continue.cl)
[OK] G8_Math (clisp test/w/G8_Math.cl)
[OK] G8_RequireSyntax (clisp test/w/G8_RequireSyntax.cl)
[FAILED] G9_BinaryTrees (clisp test/w/G9_BinaryTrees.cl)
*** - EVAL: variable CLASS has no value

[FAILED] G9_BubbleSort (clisp test/w/G9_BubbleSort.cl)
*** - NTH: #(1 5 0 2 6) is not a list

[OK] G9_Fibonacci (clisp test/w/G9_Fibonacci.cl)
[OK] G9_MathSqrt (clisp test/w/G9_MathSqrt.cl)
[FAILED] Gx_Utf8String (clisp test/w/Gx_Utf8String.cl)
*** - PROGN: variable いう has no value

# of OK: 33, # of FAILED: 15
```
#### after

```
[OK] G0_HelloWorld (clisp test/w/G0_HelloWorld.cl)
[OK] G1_Function (clisp test/w/G1_Function.cl)
[OK] G1_Grouping (clisp test/w/G1_Grouping.cl)
[OK] G1_If (clisp test/w/G1_If.cl)
[OK] G1_Let (clisp test/w/G1_Let.cl)
[OK] G1_Operator (clisp test/w/G1_Operator.cl)
[OK] G1_StringInterpolation (clisp test/w/G1_StringInterpolation.cl)
[OK] G1_Var (clisp test/w/G1_Var.cl)
[OK] G1_While (clisp test/w/G1_While.cl)
[OK] G1_WhileBreak (clisp test/w/G1_WhileBreak.cl)
[OK] G2_Asm (clisp test/w/G2_Asm.cl)
[OK] G2_CrossReferenceFunction (clisp test/w/G2_CrossReferenceFunction.cl)
[OK] G2_FunctionNoReturn (clisp test/w/G2_FunctionNoReturn.cl)
[OK] G2_FunctionParameter (clisp test/w/G2_FunctionParameter.cl)
[OK] G2_LetInFunction (clisp test/w/G2_LetInFunction.cl)
[OK] G2_Precedence (clisp test/w/G2_Precedence.cl)
[OK] G3_Boolean (clisp test/w/G3_Boolean.cl)
[OK] G3_Float (clisp test/w/G3_Float.cl)
[OK] G3_Int (clisp test/w/G3_Int.cl)
[OK] G3_IntArray (clisp test/w/G3_IntArray.cl)
[OK] G3_IntMap (clisp test/w/G3_IntMap.cl)
[OK] G3_Null (clisp test/w/G3_Null.cl)
[OK] G3_String (clisp test/w/G3_String.cl)
[OK] G3_StringConcat (clisp test/w/G3_StringConcat.cl)
[OK] G3_StringInterpolation (clisp test/w/G3_StringInterpolation.cl)
[OK] G4_KeyNotFound (clisp test/w/G4_KeyNotFound.cl)
[OK] G4_OutOfIndex (clisp test/w/G4_OutOfIndex.cl)
[FAILED] G4_SyntaxError (clisp test/w/G4_SyntaxError.cl)
*** - READ from
      #<INPUT BUFFERED FILE-STREAM CHARACTER #P"test/w/G4_SyntaxError.cl" @22>
      : there is no package with name "TEST/BUN/G4_SYNTAXERROR.BUN"

[OK] G4_Throw (clisp test/w/G4_Throw.cl)
[OK] G4_Try (clisp test/w/G4_Try.cl)
[OK] G4_ZeroDivision (clisp test/w/G4_ZeroDivision.cl)
[OK] G5_ApplyFunction (clisp test/w/G5_ApplyFunction.cl)
[OK] G5_LetFunction (clisp test/w/G5_LetFunction.cl)
[OK] G5_VarFunction (clisp test/w/G5_VarFunction.cl)
[OK] G6_Class (clisp test/w/G6_Class.cl)
[OK] G6_Constructor (clisp test/w/G6_Constructor.cl)
[OK] G6_DynamicBinding (clisp test/w/G6_DynamicBinding.cl)
[OK] G6_InstanceOf (clisp test/w/G6_InstanceOf.cl)
[OK] G6_SubClass (clisp test/w/G6_SubClass.cl)
[OK] G7_InferFunction (clisp test/w/G7_InferFunction.cl)
[OK] G8_Continue (clisp test/w/G8_Continue.cl)
[OK] G8_Math (clisp test/w/G8_Math.cl)
[OK] G8_RequireSyntax (clisp test/w/G8_RequireSyntax.cl)
[OK] G9_BinaryTrees (clisp test/w/G9_BinaryTrees.cl)
[OK] G9_BubbleSort (clisp test/w/G9_BubbleSort.cl)
[OK] G9_Fibonacci (clisp test/w/G9_Fibonacci.cl)
[OK] G9_MathSqrt (clisp test/w/G9_MathSqrt.cl)
[OK] Gx_Utf8String (clisp test/w/Gx_Utf8String.cl)
# of OK: 47, # of FAILED: 1
```
